### PR TITLE
Add conda environment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ conda env create -f environment.win64_cpu.yml
 ```
 conda env create -f environment.win64_gpu.yml
 ```
+**Linux (CPU-only):**
+```
+conda env create -f environment.linux_cpu.yml
+```
+**Linux (GPU):**
+```
+conda env create -f environment.linux_gpu.yml
+```
 
 3. Activate the new environment:
 ```

--- a/README.md
+++ b/README.md
@@ -41,3 +41,41 @@ pip install -U git+https://github.com/dattalab/keypoint-moseq
 ```
 python -m ipykernel install --user --name=keypoint_moseq
 ```
+
+### Alternative: Conda environment installation
+As an alternative, you can install directly from conda environment files. This will automatically install the appropriate GPU drivers and other dependencies.
+
+1. Clone the repository:
+```
+git clone https://github.com/dattalab/keypoint-moseq && cd keypoint-moseq
+```
+
+2. Install the appropriate conda environment for your platform:
+**Windows (CPU-only):**
+```
+conda env create -f environment.win64_cpu.yml
+```
+**Windows (GPU):**
+```
+conda env create -f environment.win64_gpu.yml
+```
+
+3. Activate the new environment:
+```
+conda activate keypoint_moseq
+```
+
+### Troubleshooting
+#### `UNKNOWN: no kernel image is available for execution on the device`
+If you're running into issues when trying to use the GPU-accelerated version, you might see this error message:
+```
+jaxlib.xla_extension.XlaRuntimeError: UNKNOWN: no kernel image is available for execution on the device
+```
+First, check if Jax can detect your GPU:
+```
+(keypoint_moseq) λ python -c "import jax; print(jax.default_backend())"
+gpu
+```
+If it can't, then you might not be using the right version of `cudatoolkit` or `cudnn`. If you installed these via `conda`, you can check by doing a `conda list | grep cud`.
+
+If you are on the right versions, try [updating your GPU driver to the latest version](https://nvidia.com/drivers).

--- a/environment.linux_cpu.yml
+++ b/environment.linux_cpu.yml
@@ -1,0 +1,16 @@
+name: keypoint_moseq
+
+channels:
+  - defaults
+  - conda-forge
+
+dependencies:
+  - python=3.9
+  - pytables
+  - conda-forge::jax=0.3.22
+  - conda-forge::jaxlib=0.3.22=*cpu*
+  - pip
+  - pip:
+    - "git+https://github.com/dattalab/jax-moseq.git@32c5286b5f11e260cb95840572beea736c3d1a0f#egg=jax-moseq"
+    - "--editable=."
+    - jupyterlab

--- a/environment.linux_gpu.yml
+++ b/environment.linux_gpu.yml
@@ -1,0 +1,20 @@
+name: keypoint_moseq
+
+channels:
+  - defaults
+  - conda-forge
+  - nvidia
+
+dependencies:
+  - python=3.9
+  - pytables
+  - cudatoolkit=11.2
+  - cudnn=8.2
+  - conda-forge::jax=0.3.22
+  - conda-forge::jaxlib=0.3.22=*cuda*
+  - cuda-nvcc
+  - pip
+  - pip:
+    - "git+https://github.com/dattalab/jax-moseq.git@32c5286b5f11e260cb95840572beea736c3d1a0f#egg=jax-moseq"
+    - "--editable=."
+    - jupyterlab

--- a/environment.linux_gpu.yml
+++ b/environment.linux_gpu.yml
@@ -1,17 +1,15 @@
 name: keypoint_moseq
 
 channels:
-  - defaults
   - conda-forge
   - nvidia
+  - defaults
 
 dependencies:
   - python=3.9
   - pytables
-  - cudatoolkit=11.2
-  - cudnn=8.2
-  - conda-forge::jax=0.3.22
-  - conda-forge::jaxlib=0.3.22=*cuda*
+  - jaxlib=0.3.22=*cuda*
+  - jax
   - cuda-nvcc
   - pip
   - pip:

--- a/environment.win64_cpu.yml
+++ b/environment.win64_cpu.yml
@@ -1,0 +1,16 @@
+name: keypoint_moseq
+
+channels:
+  - defaults
+  - conda-forge
+
+dependencies:
+  - python=3.9
+  - pytables
+  - pip
+  - pip:
+    - jax==0.3.22
+    - "https://whls.blob.core.windows.net/unstable/cpu/jaxlib-0.3.22-cp39-cp39-win_amd64.whl"
+    - "git+https://github.com/dattalab/jax-moseq.git@32c5286b5f11e260cb95840572beea736c3d1a0f#egg=jax-moseq"
+    - "--editable=."
+    - jupyterlab

--- a/environment.win64_gpu.yml
+++ b/environment.win64_gpu.yml
@@ -8,16 +8,13 @@ channels:
 dependencies:
   - python=3.9
   - pytables
-  # - jaxlib=*=*cuda*
-  # - jax
-  # - cudatoolkit=11
-  # - cudnn=8.2
-  # - cuda-nvcc
+  - cudatoolkit=11.1
+  - cudnn=8.2
+  - cuda-nvcc
   - pip
   - pip:
     - jax==0.3.22
-    # - "https://whls.blob.core.windows.net/unstable/cuda111/jaxlib-0.3.22+cuda11.cudnn82-cp39-cp39-win_amd64.whl"
-    - "https://whls.blob.core.windows.net/unstable/cpu/jaxlib-0.3.22-cp39-cp39-win_amd64.whl"
+    - "https://whls.blob.core.windows.net/unstable/cuda111/jaxlib-0.3.22+cuda11.cudnn82-cp39-cp39-win_amd64.whl"
     - "git+https://github.com/dattalab/jax-moseq.git@32c5286b5f11e260cb95840572beea736c3d1a0f#egg=jax-moseq"
     - "--editable=."
     - jupyterlab

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -1,0 +1,23 @@
+name: keypoint_moseq
+
+channels:
+  - defaults
+  - conda-forge
+  - nvidia
+
+dependencies:
+  - python=3.9
+  - pytables
+  # - jaxlib=*=*cuda*
+  # - jax
+  # - cudatoolkit=11
+  # - cudnn=8.2
+  # - cuda-nvcc
+  - pip
+  - pip:
+    - jax==0.3.22
+    # - "https://whls.blob.core.windows.net/unstable/cuda111/jaxlib-0.3.22+cuda11.cudnn82-cp39-cp39-win_amd64.whl"
+    - "https://whls.blob.core.windows.net/unstable/cpu/jaxlib-0.3.22-cp39-cp39-win_amd64.whl"
+    - "git+https://github.com/dattalab/jax-moseq.git@32c5286b5f11e260cb95840572beea736c3d1a0f#egg=jax-moseq"
+    - "--editable=."
+    - jupyterlab


### PR DESCRIPTION
This PR adds working `environment.yml` files which define fully self-contained conda environments for Windows and Linux, both on CPU and GPU.

This is nice because it handles CUDA dependencies and their interactions with Jax so things "just work".

This was tested on Windows 10 and Ubuntu 22.04, both with GPU.