### PR TITLE
make editable refer to root dir with setup.py

### DIFF
--- a/conda_envs/environment.linux_cpu.yml
+++ b/conda_envs/environment.linux_cpu.yml
@@ -12,5 +12,5 @@ dependencies:
   - pip
   - pip:
     - "jax-moseq==0.0.0"
-    - "--editable=."
+    - "--editable=../"
     - jupyterlab

--- a/conda_envs/environment.linux_gpu.yml
+++ b/conda_envs/environment.linux_gpu.yml
@@ -14,5 +14,5 @@ dependencies:
   - pip
   - pip:
     - "jax-moseq==0.0.0"
-    - "--editable=."
+    - "--editable=../"
     - jupyterlab

--- a/conda_envs/environment.win64_cpu.yml
+++ b/conda_envs/environment.win64_cpu.yml
@@ -12,5 +12,5 @@ dependencies:
     - jax==0.3.22
     - "https://whls.blob.core.windows.net/unstable/cpu/jaxlib-0.3.22-cp39-cp39-win_amd64.whl"
     - "jax-moseq==0.0.0"
-    - "--editable=."
+    - "--editable=../"
     - jupyterlab

--- a/conda_envs/environment.win64_gpu.yml
+++ b/conda_envs/environment.win64_gpu.yml
@@ -16,5 +16,5 @@ dependencies:
     - jax==0.3.22
     - "https://whls.blob.core.windows.net/unstable/cuda111/jaxlib-0.3.22+cuda11.cudnn82-cp39-cp39-win_amd64.whl"
     - "jax-moseq==0.0.0"
-    - "--editable=."
+    - "--editable=../"
     - jupyterlab


### PR DESCRIPTION
I'm using an M1 chip and I encountered issue #5 . As suggested, I ran:
```
git clone https://github.com/dattalab/keypoint-moseq && cd keypoint-moseq
```
```
conda env create -f conda_envs/environment.linux_cpu.yml
```
And encountered the following error:
```
Pip subprocess error:                                                           
ERROR: file:///Users/armand/Documents/keypoint-moseq/conda_envs (from -r /Users/armand/Documents/keypoint-moseq/conda_envs/condaenv.m8fzb9y8.requirements.txt (line 2)) does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.                                                                  
                                                                                
failed                                                                          
                                                                                
CondaEnvException: Pip failed    
```
Which turned out to be caused by the line --editable in the environment.linux_cpu.yml not referring to the root directory containing the setup.py file. After making the changes in this commit, I successfully created the conda environment. 
I assume this must be true for all 4 environments in conda_envs/ directory so I made the same change in all 4 environment files.

