### PR TITLE
Add Mac (CPU) conda environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install keypoint-moseq
 python -m ipykernel install --user --name=keypoint_moseq
 ```
 
-### Option 2: Conda environment installation
+## Option 2: Conda environment installation
 As an alternative, you can install directly from conda environment files. This will automatically install the appropriate GPU drivers and other dependencies.
 
 1. Clone the repository:
@@ -61,9 +61,14 @@ conda env create -f conda_envs/environment.win64_gpu.yml
 # Linux (CPU-only)
 conda env create -f conda_envs/environment.linux_cpu.yml
 
-#Linux (GPU)
+# Linux (GPU)
 conda env create -f conda_envs/environment.linux_gpu.yml
+
+# Mac (CPU-only)
+conda env create -f conda_envs/environment.mac_cpu.yml
 ```
+
+See [this issue](https://github.com/dattalab/keypoint-moseq/issues/5) for updates regarding Apple Silicon (M1/M2) support. For now, you can use the Mac (CPU) version on newer Macs.
 
 3. Activate the new environment:
 ```

--- a/conda_envs/environment.mac_cpu.yml
+++ b/conda_envs/environment.mac_cpu.yml
@@ -1,0 +1,18 @@
+name: keypoint_moseq
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.9
+  - pytables
+  - openblas
+  - numpy=1.23.5
+  - pip
+  - pip:
+    - jax==0.3.22
+    - jaxlib==0.3.22
+    - "jax-moseq==0.0.0"
+    - "--editable=../"
+    - jupyterlab

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -50,8 +50,13 @@ Install the appropriate conda environment for your platform::
    # Linux (CPU-only)
    conda env create -f conda_envs/environment.linux_cpu.yml
 
-   #Linux (GPU)
+   # Linux (GPU)
    conda env create -f conda_envs/environment.linux_gpu.yml
+
+   # Mac (CPU-only)
+   conda env create -f conda_envs/environment.mac_cpu.yml
+
+See `this issue <https://github.com/dattalab/keypoint-moseq/issues/5>`_ for updates regarding Apple Silicon (M1/M2) support. For now, you can use the Mac (CPU) version on newer Macs.
 
 Activate the new environment::
 


### PR DESCRIPTION
Adds conda environment for installing with CPU-only Jax and associated instructions.