### PR TITLE
Added parallel_message_passing flag

### DIFF
--- a/keypoint_moseq/fitting.py
+++ b/keypoint_moseq/fitting.py
@@ -197,7 +197,7 @@ def fit_model(model,
 
             try: model = _wrapped_resample(
                 data, model, pbar=pbar, ar_only=ar_only, verbose=verbose,
-                parallel_kalman = parallel_message_passing)
+                parallel_message_passing = parallel_message_passing)
             except StopResampling: break
 
             if history_every_n_iters>0 and (iteration%history_every_n_iters)==0:
@@ -407,7 +407,7 @@ def apply_model(*, params, coordinates, confidences=None, num_iters=20,
             try: model = _wrapped_resample(
                     data, model, pbar=pbar, ar_only=ar_only, 
                     states_only=True, verbose=verbose,
-                    parallel_kalman = parallel_message_passing)
+                    parallel_message_passing = parallel_message_passing)
             except StopResampling: break
 
     return extract_results(

--- a/keypoint_moseq/fitting.py
+++ b/keypoint_moseq/fitting.py
@@ -147,10 +147,11 @@ def fit_model(model,
     save_progress_figs : bool, default=True
         If True, save the progress plots to disk.
 
-    parallel_message_passing : bool, default=True,
+    parallel_message_passing : bool, default=None,
         Use parallel implementation of Kalman sampling, which can be faster
         but has a significantly longer jit time.  To enable and skip checking
-        for parallel-computing backend, set to 'force.'
+        for parallel-computing backend, set to 'force.' To enable whenever a
+        parallel-computing backend is present, set to `None`.
         
     Returns
     -------
@@ -179,13 +180,15 @@ def fit_model(model,
 
     if parallel_message_passing == 'force':
         parallel_message_passing = True
+    if parallel_message_passing is None:
+        parallel_message_passing = jax.default_backend() != 'cpu'
     else:
         if parallel_message_passing and jax.default_backend() == 'cpu':
             warnings.warn(fill(
                 'Setting parallel_message_passing = True when JAX is'
-                'CPU-bound can result in long jit times and speed increase for'
-                'calculations. To suppress this message, set the parameter to'
-                '"force".'))
+                'CPU-bound can result in long jit times without speed increase '
+                'for calculations. To suppress this message, set the parameter'
+                'to "force".'))
 
     if history is None: history = {}
 

--- a/keypoint_moseq/fitting.py
+++ b/keypoint_moseq/fitting.py
@@ -66,6 +66,7 @@ def fit_model(model,
               states_in_history=True,
               plot_every_n_iters=10,  
               save_progress_figs=True,
+              parallel_kalman=True,
               **kwargs):
 
     """
@@ -145,6 +146,10 @@ def fit_model(model,
 
     save_progress_figs : bool, default=True
         If True, save the progress plots to disk.
+
+    parallel_kalman : bool, default=True,
+        Use parallel implementation of Kalman sampling, which can be faster
+        but has a significantly longer jit time.
         
     Returns
     -------
@@ -177,7 +182,8 @@ def fit_model(model,
         for iteration in pbar:
 
             try: model = _wrapped_resample(
-                data, model, pbar=pbar, ar_only=ar_only, verbose=verbose)
+                data, model, pbar=pbar, ar_only=ar_only, verbose=verbose,
+                parallel_kalman = parallel_kalman)
             except StopResampling: break
 
             if history_every_n_iters>0 and (iteration%history_every_n_iters)==0:
@@ -307,7 +313,9 @@ def extract_results(*, params, states, labels, save_results=True,
 
 def apply_model(*, params, coordinates, confidences=None, num_iters=20, 
                 ar_only=False, save_results=True, verbose=False,
-                project_dir=None, name=None, results_path=None, **kwargs): 
+                project_dir=None, name=None, results_path=None,
+                parallel_kalman=True,
+                **kwargs):
     """
     Apply a model to new data.
 
@@ -349,6 +357,10 @@ def apply_model(*, params, coordinates, confidences=None, num_iters=20,
     results_path : str, default=None
         Optional path for saving model outputs.
 
+    parallel_kalman : bool, default=True,
+        Use parallel implementation of Kalman sampling, which can be faster
+        but has a significantly longer jit time.
+    
     Returns
     -------
     results_dict : dict
@@ -369,7 +381,8 @@ def apply_model(*, params, coordinates, confidences=None, num_iters=20,
         for iteration in pbar:
             try: model = _wrapped_resample(
                     data, model, pbar=pbar, ar_only=ar_only, 
-                    states_only=True, verbose=verbose)
+                    states_only=True, verbose=verbose,
+                    parallel_kalman = parallel_kalman)
             except StopResampling: break
 
     return extract_results(


### PR DESCRIPTION
  Added `parallel_message_passing` flag in `fit_model` to use the new parallel posterior sampler in jax-moseq (dattalab/jax-moseq#23) and dynamax (probml/dynamax#324) when in a suitable parallel computing environment.