### PR TITLE
Return sampled instances in generate_grid_movies

### DIFF
--- a/keypoint_moseq/viz.py
+++ b/keypoint_moseq/viz.py
@@ -1210,7 +1210,7 @@ def generate_grid_movies(
 
         path = os.path.join(output_dir, f"syllable{syllable}.mp4")
         write_video_clip(frames, path, fps=fps, quality=quality)
-
+    return sampled_instances
 
 def get_limits(
     coordinates,


### PR DESCRIPTION
Since the snippets generated by `generate_grid_movies` are all random, it will be great to return the sampled instances for user to go back to specific video and frame