### PR TITLE
Fix installation for GPU on Windows

### DIFF
--- a/conda_envs/environment.win64_gpu.yml
+++ b/conda_envs/environment.win64_gpu.yml
@@ -7,9 +7,10 @@ channels:
 
 dependencies:
   - python=3.9
-  - cudatoolkit=11.1
-  - cudnn=8.2
-  - cuda-nvcc
+  - conda-forge::cudatoolkit=11.8.0
+  - conda-forge::cudnn=8.8.0.121
+  - nvidia::cuda-nvcc
+  - pytables
   - pip
   - pip:
     - jax==0.3.22


### PR DESCRIPTION
`cudatoolkit` and `cudnn` are now installed from proper channels - newer versions but since they are compatible it doesn't hurt to have them. `pytables` is also added so the extra step from installation can be skipped. Now installation is fully complete just by running env creation from the file