### PR TITLE
Update install.rst

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -24,11 +24,11 @@ Use conda environment files to automatically install the appropriate GPU drivers
 
 Install the appropriate conda environment for your platform::
 
-   # Windows (CPU-only)
-   conda env create -f conda_envs\environment.win64_cpu.yml
+   # Windows WSL2 (CPU-only)
+   conda env create -f conda_envs/environment.win64_cpu.yml
 
-   # Windows (GPU)
-   conda env create -f conda_envs\environment.win64_gpu.yml
+   # Windows WSL2 (GPU)
+   conda env create -f conda_envs/environment.win64_gpu.yml
 
    # Linux (CPU-only)
    conda env create -f conda_envs/environment.linux_cpu.yml


### PR DESCRIPTION
Since WSL2 is a linux kernel, path syntax can use a `/` instead of a `\` to denote folders.