### PR TITLE
Making format_data deterministic

### DIFF
--- a/keypoint_moseq/util.py
+++ b/keypoint_moseq/util.py
@@ -1071,7 +1071,8 @@ def format_data(
     conf = conf + conf_pseudocount
 
     if added_noise_level > 0:
-        Y += np.random.uniform(-added_noise_level, added_noise_level, Y.shape)
+        rng = np.random.default_rng(42)
+        Y += rng.uniform(-added_noise_level, added_noise_level, Y.shape)
 
     data = jax.device_put({"mask": mask, "Y": Y, "conf": conf})
     return data, metadata


### PR DESCRIPTION
Sets the same random seed every time when adding random noise to Y in format_data. Paired with a PR in jax-moseq for making PCA deterministic as well in order to make the whole pipeline more deterministic for reproducibility and easier debugging.