### PR TITLE
WIP: JAX/NumPy compat shims + nanmedian outlier fix

### DIFF
--- a/keypoint_moseq/__init__.py
+++ b/keypoint_moseq/__init__.py
@@ -1,3 +1,31 @@
+# -----------------------------------------------------------------------------
+# JAX compatibility shim for chex 0.1.6 with newer JAX versions
+# chex expects deprecated jax.interpreters.* APIs that were removed
+# Modern JAX unifies all array types into jax.Array
+# -----------------------------------------------------------------------------
+import jax
+
+# Shim for jax.interpreters.pxla.ShardedDeviceArray
+if not hasattr(jax.interpreters.pxla, 'ShardedDeviceArray'):
+    jax.interpreters.pxla.ShardedDeviceArray = jax.Array
+
+# Shim for jax.interpreters.batching.BatchTracer
+if not hasattr(jax.interpreters.batching, 'BatchTracer'):
+    jax.interpreters.batching.BatchTracer = jax.Array
+
+# Shim for jax.interpreters.xla.DeviceArray and _DeviceArray
+if not hasattr(jax.interpreters.xla, 'DeviceArray'):
+    jax.interpreters.xla.DeviceArray = jax.Array
+if not hasattr(jax.interpreters.xla, '_DeviceArray'):
+    jax.interpreters.xla._DeviceArray = jax.Array
+
+# NumPy 2.0 compatibility shim
+# np.bool8 was removed in numpy 2.0, bokeh still uses it
+import numpy as np
+if not hasattr(np, 'bool8'):
+    np.bool8 = np.bool_
+# -----------------------------------------------------------------------------
+
 # use double-precision by default
 from jax import config
 

--- a/keypoint_moseq/util.py
+++ b/keypoint_moseq/util.py
@@ -1446,7 +1446,7 @@ def get_distance_to_medoid(coordinates: np.ndarray) -> np.ndarray:
     distances: ndarray of shape (n_frames, n_keypoints)
         Euclidean distances from each keypoint to the medoid position at each frame.
     """
-    medoids = np.median(coordinates, axis=1)  # (n_frames, keypoint_dim)
+    medoids = np.nanmedian(coordinates, axis=1)  # (n_frames, keypoint_dim)
     return np.linalg.norm(coordinates - medoids[:, None, :], axis=-1)  # (n_frames, n_keypoints)
 
 
@@ -1481,8 +1481,8 @@ def find_medoid_distance_outliers(
             Distance thresholds used to classify outlier timepoints for each keypoint.
     """
     distances = get_distance_to_medoid(coordinates)  # (n_frames, n_keypoints)
-    medians = np.median(distances, axis=0)  # (n_keypoints,)
-    MADs = np.median(np.abs(distances - medians[None, :]), axis=0)  # (n_keypoints,)
+    medians = np.nanmedian(distances, axis=0)  # (n_keypoints,)
+    MADs = np.nanmedian(np.abs(distances - medians[None, :]), axis=0)  # (n_keypoints,)
     outlier_thresholds = MADs * outlier_scale_factor + medians  # (n_keypoints,)
     outlier_mask = distances > outlier_thresholds[None, :]  # (n_frames, n_keypoints)
     return {"mask": outlier_mask, "thresholds": outlier_thresholds}


### PR DESCRIPTION
## Status: Needs review — not sure if this is complete

I found this branch with uncommitted changes and committed them so they wouldn't get lost. **I don't remember if I was done or mid-way through something.** Please check before merging.

## Changes

### JAX compatibility shims (`__init__.py`)
- Shim deprecated `jax.interpreters.*` APIs (`pxla.ShardedDeviceArray`, `batching.BatchTracer`, `xla.DeviceArray`, `xla._DeviceArray`) for newer JAX versions that removed them (chex 0.1.6 compat)
- Shim `np.bool8` removed in NumPy 2.0 (bokeh compat)

### NaN-safety in outlier detection (`util.py`)
- Use `nanmedian` instead of `median` in `get_distance_to_medoid` and `find_medoid_distance_outliers` to handle frames with NaN coordinates

## TODO before merging
- [ ] Check if there were more shims or fixes planned
- [ ] There's an untracked `tests/` directory on this branch — were tests being written?
- [ ] Verify the shims actually work with the target JAX/chex versions
- [ ] Verify nanmedian fix doesn't change behavior for data without NaNs