### PR TITLE
Consolidate docs deps onto setup.cfg [dev] extra

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,7 @@ build:
 
 python:
   install:
-    - requirements: docs/requirements.txt
     - method: pip
       path: .
+      extra_requirements:
+        - dev

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-# docs/requirements.txt
-sphinx
-sphinx-rtd-theme
-autodocsumm
-myst-nb
-requests>=2.5.0
-jax[cpu]==0.4.10
-ml_dtypes==0.2.0
-scipy==1.11.3


### PR DESCRIPTION
## Summary

- The `stable` RTD build is failing because `docs/requirements.txt`
  pins `jax[cpu]==0.4.10`, and the corresponding `jaxlib==0.4.10`
  wheels are no longer published on PyPI (PyPI's release index for
  `jaxlib` lists 38 releases, with `0.4.18` as the lowest; `0.4.10`
  is absent). RTD's `pip install -r docs/requirements.txt` step
  therefore exits 1. See failing build
  [#31563994](https://readthedocs.org/projects/keypoint-moseq/builds/31563994/).
- The sphinx tooling listed in `docs/requirements.txt` (sphinx,
  sphinx-rtd-theme, autodocsumm, myst-nb) was already duplicated in
  `setup.cfg`'s `[options.extras_require] dev`. The runtime deps
  duplicated there (jax, scipy, ml_dtypes) were pinned more
  restrictively than `install_requires`, and those exact-version
  wheels are no longer available on PyPI.
- This PR deletes `docs/requirements.txt` and points
  `.readthedocs.yml` at `pip install .[dev]`, so `install_requires`
  becomes the single source of truth for runtime deps and the `dev`
  extra owns the docs-build tooling.

## Test plan

- [x] Reproduced the failure in a fresh `uv venv --python 3.10`
      matching RTD's environment (Ubuntu 22.04, Python 3.10).
- [x] Ran `uv pip install .[dev]` + `sphinx-build -b html docs/source <out>`
      in that venv — build succeeds with exit 0 and 17 pre-existing
      warnings (no new ones introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
